### PR TITLE
Default Value For workspace_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ EMAIL=your_toggl_email
 PASSWORD=your_toggl_password
 ```
 
+If you are using Toggl API tokens:
+```bash
+EMAIL=xxxx
+PASSWORD="api_token"
+```
+Where `xxxx` indicates your personal token
+
 ### Installation
 
 First install uv:

--- a/toggl-mcp-server/toggl_mcp_server.py
+++ b/toggl-mcp-server/toggl_mcp_server.py
@@ -847,7 +847,7 @@ async def update_projects(
     return response
 
 @mcp.tool()
-async def get_all_projects(workspace_name: Optional[str]) -> Union[dict, str]:
+async def get_all_projects(workspace_name: Optional[str] = None) -> Union[dict, str]:
     """
     Retrieve all projects in the user's Toggl workspace.
 


### PR DESCRIPTION
Without providing the default value I was receiving MCP errors that workspace_name was a required field. Also provided instructions for using the Toggl api token.